### PR TITLE
Night Arming and LCD Events

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ad2usb",
   "description": "A driver for the Nutech AD2USB Ademco Vista security panel interface",
   "author": "Alex Wolfe <alexkwolfe@gmail.com>",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "main": "lib/ad2usb.js",
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "ad2usb",
   "description": "A driver for the Nutech AD2USB Ademco Vista security panel interface",
   "author": "Alex Wolfe <alexkwolfe@gmail.com>",
-  "version": "1.1.1",
+  "contributors": ["Alistair Galbraith <github@alistairs.net>"],
+  "version": "1.0.2",
   "main": "lib/ad2usb.js",
   "licenses": [
     {

--- a/src/ad2usb.coffee
+++ b/src/ad2usb.coffee
@@ -53,16 +53,7 @@ class Alarm extends EventEmitter
     disarmed = sec1.shift() == '1'
     armedAway = sec1.shift() == '1'
     armedStay = sec1.shift() == '1'
-    if disarmed or armedAway or armedStay
-      if disarmed and !@disarmed
-        @emit 'disarmed'
-      else if armedAway and !@armedAway
-        @emit 'armedAway'
-      else if armedStay and !@armedStay
-        @emit 'armedStay'
-      @disarmed = disarmed
-      @armedAway = armedAway
-      @armedStay = armedStay
+    
 
     @state 'backlight', sec1.shift() == '1'
     @state 'programming', sec1.shift() == '1'
@@ -91,8 +82,29 @@ class Alarm extends EventEmitter
     sections.push parts[2].replace(/[\[\]]/g, '')
 
     # Section 4: "****DISARMED****  Ready to Arm  "
-    @emit 'lcdtext', parts[3]
+    lcdtext = parts[3].replace(/"/g,"")
+    if lcdtext != @lcdtext
+      @emit 'lcdtext', lcdtext
+      @lcdtext = lcdtext
     sections.push parts[3]
+
+    # Process arm state events, which also need LCD text
+    armedNight = armedStay and lcdtext.indexOf("***NIGHT-STAY***") > -1
+    if armedNight and armedStay
+      armedStay = false
+    if disarmed or armedAway or armedStay or armedNight
+      if disarmed and !@disarmed
+        @emit 'disarmed'
+      else if armedAway and !@armedAway
+        @emit 'armedAway'
+      else if armedStay and !@armedStay
+        @emit 'armedStay'
+      else if armedNight and !@armedNight
+        @emit 'armedNight'
+      @disarmed = disarmed
+      @armedAway = armedAway
+      @armedStay = armedStay
+      @armedNight = armedNight
 
     @emit.apply @, ['raw'].concat(sections) # raw emit for debugging or additional handling
 

--- a/src/ad2usb.coffee
+++ b/src/ad2usb.coffee
@@ -91,6 +91,7 @@ class Alarm extends EventEmitter
     sections.push parts[2].replace(/[\[\]]/g, '')
 
     # Section 4: "****DISARMED****  Ready to Arm  "
+    @emit 'lcdtext', parts[3]
     sections.push parts[3]
 
     @emit.apply @, ['raw'].concat(sections) # raw emit for debugging or additional handling
@@ -172,6 +173,18 @@ class Alarm extends EventEmitter
   ###
   armStay: (code, callback) ->
     @send "#{code}3", callback if code
+
+
+  ###
+  Public: Arm the alarm in night stay mode.
+
+  code: The user code to use to arm the alarm.
+  callback: function invoked when interface acknowledegs command (optional)
+
+  Returns true if command is sent, otherwise false
+  ###
+  armNight: (code, callback) ->
+    @send "#{code}33", callback if code
 
 
   ###


### PR DESCRIPTION
I added a couple of features I needed :)
1. Night arming support (Code + 33) and events (based on STAY flag, and LCD containing NIGHT-STAY)
2. LCD event notifications for keypad tracking events

I also updated the package descriptor to increment the version number slightly
